### PR TITLE
Updated to python3, added mqtt option, allows for initial no data package

### DIFF
--- a/meater.py
+++ b/meater.py
@@ -21,10 +21,14 @@ class MeaterProbe:
       
    @staticmethod
    def toCelsius(value):
+      if value is None:
+         return None
       return (float(value)+8.0)/16.0
 
    @staticmethod
    def toFahrenheit(value):
+      if value is None:
+         return None
       return ((MeaterProbe.toCelsius(value)*9)/5)+32.0
 
    def getTip(self):
@@ -70,10 +74,10 @@ class MeaterProbe:
          self._tip = MeaterProbe.bytesToInt(tempBytes[0], tempBytes[1])
          self._ambient = MeaterProbe.convertAmbient(tempBytes)
          self._battery = MeaterProbe.bytesToInt(batteryBytes[0], batteryBytes[1])*10
-         (self._firmware, self._id) = str(self.readCharacteristic(22)).split("_")
+         (self._firmware, self._id) = self.readCharacteristic(22).decode().split('_')
          self._lastUpdate = time.time()
       else:
-         self._tip = self._ambient = self._ambient = self._battery = self._firmware = self._id = self._lastUpdate = None
+         self._tip = self._ambient = self._battery = self._firmware = self._id = self._lastUpdate = None
 
    def __str__(self):
       if self._lastUpdate is not None:

--- a/meater.py
+++ b/meater.py
@@ -28,54 +28,34 @@ class MeaterProbe:
       return ((MeaterProbe.toCelsius(value)*9)/5)+32.0
 
    def getTip(self):
-      if hasattr(self, '_tip'):
-         return self._tip
-      return None
+      return self._tip
 
    def getTipF(self):
-      if hasattr(self, '_tip'):
-         return MeaterProbe.toFahrenheit(self._tip)
-      return None
+      return MeaterProbe.toFahrenheit(self._tip)
 
    def getTipC(self):
-      if hasattr(self, '_tip'):
-         return MeaterProbe.toCelsius(self._tip)
-      return None
-
+      return MeaterProbe.toCelsius(self._tip)
+   
    def getAmbientF(self):
-      if hasattr(self, '_ambient'):
-         return MeaterProbe.toFahrenheit(self._ambient)
-      return None
-
+      return MeaterProbe.toFahrenheit(self._ambient)
+   
    def getAmbient(self):
-      if hasattr(self, '_ambient'):
-         return self._ambient
-      return None
-
+      return self._ambient
+   
    def getAmbientC(self):
-      if hasattr(self, '_ambient'):
-         return MeaterProbe.toCelsius(self._ambient)
-      return None
-
+      return MeaterProbe.toCelsius(self._ambient)
+   
    def getBattery(self):
-      if hasattr(self, '_ambient'):
-         return self._battery
-      return None
-
+      return self._battery
+   
    def getAddress(self):
-      if hasattr(self, '_addr'):
-         return self._addr
-      return None
-
+      return self._addr
+   
    def getID(self):
-      if hasattr(self, '_id'):
-         return self._id
-      return None
-
+      return self._id
+   
    def getFirmware(self):
-      if hasattr(self, '_firmware'):
-         return self._firmware
-      return None
+      return self._firmware
 
    def connect(self):
       self._dev = btle.Peripheral(self._addr)
@@ -92,8 +72,10 @@ class MeaterProbe:
          self._battery = MeaterProbe.bytesToInt(batteryBytes[0], batteryBytes[1])*10
          (self._firmware, self._id) = str(self.readCharacteristic(22)).split("_")
          self._lastUpdate = time.time()
+      else:
+         self._tip = self._ambient = self._ambient = self._battery = self._firmware = self._id = self._lastUpdate = None
 
    def __str__(self):
-      if hasattr(self, '_lastUpdate'):
+      if self._lastUpdate is not None:
          return "%s %s probe: %s tip: %fF/%fC ambient: %fF/%fC battery: %d%% age: %ds" % (self.getAddress(), self.getFirmware(), self.getID(), self.getTipF(), self.getTipC(), self.getAmbientF(), self.getAmbientC(), self.getBattery(), time.time() - self._lastUpdate)
       return "No data yet."

--- a/meater.py
+++ b/meater.py
@@ -28,34 +28,54 @@ class MeaterProbe:
       return ((MeaterProbe.toCelsius(value)*9)/5)+32.0
 
    def getTip(self):
-      return self._tip
+      if hasattr(self, '_tip'):
+         return self._tip
+      return None
 
    def getTipF(self):
-      return MeaterProbe.toFahrenheit(self._tip)
+      if hasattr(self, '_tip'):
+         return MeaterProbe.toFahrenheit(self._tip)
+      return None
 
    def getTipC(self):
-      return MeaterProbe.toCelsius(self._tip)
+      if hasattr(self, '_tip'):
+         return MeaterProbe.toCelsius(self._tip)
+      return None
 
    def getAmbientF(self):
-      return MeaterProbe.toFahrenheit(self._ambient)
+      if hasattr(self, '_ambient'):
+         return MeaterProbe.toFahrenheit(self._ambient)
+      return None
 
    def getAmbient(self):
-      return self._ambient
+      if hasattr(self, '_ambient'):
+         return self._ambient
+      return None
 
    def getAmbientC(self):
-      return MeaterProbe.toCelsius(self._ambient)
+      if hasattr(self, '_ambient'):
+         return MeaterProbe.toCelsius(self._ambient)
+      return None
 
    def getBattery(self):
-      return self._battery
+      if hasattr(self, '_ambient'):
+         return self._battery
+      return None
 
    def getAddress(self):
-      return self._addr
+      if hasattr(self, '_addr'):
+         return self._addr
+      return None
 
    def getID(self):
-      return self._id
+      if hasattr(self, '_id'):
+         return self._id
+      return None
 
    def getFirmware(self):
-      return self._firmware
+      if hasattr(self, '_firmware'):
+         return self._firmware
+      return None
 
    def connect(self):
       self._dev = btle.Peripheral(self._addr)
@@ -66,11 +86,14 @@ class MeaterProbe:
    def update(self):
       tempBytes = self.readCharacteristic(31)
       batteryBytes = self.readCharacteristic(35)
-      self._tip = MeaterProbe.bytesToInt(tempBytes[0], tempBytes[1])
-      self._ambient = MeaterProbe.convertAmbient(tempBytes)
-      self._battery = MeaterProbe.bytesToInt(batteryBytes[0], batteryBytes[1])*10
-      (self._firmware, self._id) = str(self.readCharacteristic(22)).split("_")
-      self._lastUpdate = time.time()
+      if len(tempBytes) > 0:
+         self._tip = MeaterProbe.bytesToInt(tempBytes[0], tempBytes[1])
+         self._ambient = MeaterProbe.convertAmbient(tempBytes)
+         self._battery = MeaterProbe.bytesToInt(batteryBytes[0], batteryBytes[1])*10
+         (self._firmware, self._id) = str(self.readCharacteristic(22)).split("_")
+         self._lastUpdate = time.time()
 
    def __str__(self):
-       return "%s %s probe: %s tip: %fF/%fC ambient: %fF/%fC battery: %d%% age: %ds" % (self.getAddress(), self.getFirmware(), self.getID(), self.getTipF(), self.getTipC(), self.getAmbientF(), self.getAmbientC(), self.getBattery(), time.time() - self._lastUpdate)
+      if hasattr(self, '_lastUpdate'):
+         return "%s %s probe: %s tip: %fF/%fC ambient: %fF/%fC battery: %d%% age: %ds" % (self.getAddress(), self.getFirmware(), self.getID(), self.getTipF(), self.getTipC(), self.getAmbientF(), self.getAmbientC(), self.getBattery(), time.time() - self._lastUpdate)
+      return "No data yet."

--- a/readMeater.py
+++ b/readMeater.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
 # Find the meater address with hcitool lescan (label MEATER).
 # run readMeater.py <address>
@@ -13,12 +13,12 @@ import binascii
 
 from meater import MeaterProbe
  
-print "Connecting..."
+print("Connecting...")
 devs = [MeaterProbe(addr) for addr in sys.argv[1:]]
-print "Connected"
+print("Connected")
 
 while True:
     for dev in devs:
        dev.update()
-       print dev
+       print(dev)
     time.sleep(1)

--- a/readMeater.py
+++ b/readMeater.py
@@ -4,8 +4,8 @@
 # run readMeater.py <address>
 # python ./readMeater.py D0:D9:4F:83:E8:EB
 
-import time
 from bluepy import btle
+import json
 import time
 import click
 import paho.mqtt.client as mqtt 
@@ -31,7 +31,14 @@ def main(device, mosquitto_server):
          dev.update()
          print(dev)
          if mosquitto_server is not None:
-            client.publish("TEMPERATURE_C", dev.getTipC())
+            client.publish("meater", json.dumps({
+               'tip_C' : dev.getTipC(),
+               'ambient_C' : dev.getAmbientC(),
+               'battery' : dev.getBattery(),
+               'bluetooth_address' : dev.getAddress(),
+               'id' : dev.getID(),
+               'firmware' : dev.getFirmware(),
+            }))
       time.sleep(1)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello nathanfaber,

first a big thanks to you and your contributors, it allowed me to use my Meater from my linux laptop within minutes. :)

I changed the print command to be python3 ready and added a command line interface that allows to optionally send the data to a mqtt server.

I also had the problem when I started readMeater.py and then took the Meater out of the charging box that the first package was empty. Therefore I added a "no data" handling. I think this might also help in #5 .

Please let me know if you would like some changes (e.g. JSON format).

Thanks again and greetings from Germany
:) stefan